### PR TITLE
fix: Remove `preinstall` script so installation can occur with package managers other than `pnpm`

### DIFF
--- a/.changeset/stale-apes-punch.md
+++ b/.changeset/stale-apes-punch.md
@@ -1,0 +1,5 @@
+---
+"modern-ahocorasick": patch
+---
+
+Remove `preinstall` script so installation can occur with package managers other than `pnpm`

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "format": "pnpm prettier --check \"src/**/*.{ts,js}\" -w",
     "ls:pack": "npm pack --dry-run",
     "prepare": "ts-patch install -s",
-    "preinstall": "npx only-allow pnpm",
     "semantic-release": "semantic-release",
     "sync": "cnpm sync modern-ahocorasick"
   },


### PR DESCRIPTION
`only-allow` is probably best used for things that aren't packages, i.e. they won't be installed as a dependency.

This has resulted in https://github.com/vanilla-extract-css/vanilla-extract/issues/1225